### PR TITLE
Add basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ How Do I Use It?
 
 Don't get mad.  We use curl.
 
-    curl -X POST http://localhost:7109/events --data-binary '{
+    curl -X POST http://username:password@localhost:7109/events --data-binary '{
       "topic"       : "some-pipeline",
       "ok"          : true,
       "message"     : "Pipeline build #367 succeeded",
@@ -36,8 +36,10 @@ Don't get mad.  We use curl.
     }'
 
 Shout! keeps track of the `ok`-ness of each topic you create.
-Whenever transitions occur, either a failure (ok -> not ok) or a
-recovery (the opposite), a notification is sent.
+Whenever transitions occur, either a failure (ok -> not ok) or a recovery (the
+opposite), a notification is sent.  By default, the `username:password` pair
+is `shout:shout`, but this can be overridden by setting the `SHOUT_OPS_AUTH`
+environment variable before starting the Shout! process.
 
 No Seriously, How Do I Use It, _For Real_?
 ------------------------------------------

--- a/run.lisp
+++ b/run.lisp
@@ -18,9 +18,23 @@
   (or (sb-posix:getenv name)
       default))
 
+(defun bail (msg code)
+  (format t "[ERROR] ~A~%" msg)
+  (sb-ext::exit :code 1))
+
+(defun get-auth (env-var)
+  (let ((auth (env env-var nil)))
+    (if (null auth)
+      api::*default-auth*
+      (let ((idx (position #\: auth)))
+        (if (null idx)
+          (bail (format nil "Invalid authentication string in ~A: expecting \"username:password\"" env-var) 1)
+          (cons (subseq auth 0 idx) (subseq auth (+ idx 1))))))))
+
 (if (not (env "SHOUT_IT_OUT_LOUD" nil))
   (daemon:daemonize :exit-parent t
                     :pidfile (sb-posix:getenv "PID_FILE")))
 (api:run :port    (env "SHOUT_PORT"     api::*default-port*)
          :rules   (env "SHOUT_RULES"    api::*default-rules*)
-         :dbfile  (env "SHOUT_DATABASE" api::*default-dbfile*))
+         :dbfile  (env "SHOUT_DATABASE" api::*default-dbfile*)
+         :ops-auth (get-auth "SHOUT_OPS_AUTH"))


### PR DESCRIPTION
This adds basic auth to the /events, /state, and /states endpoints.  You
can set the username and password by setting the "SHOUT_OPS_AUTH"
environment variable to "username:password".  Otherwise it defaults to
"shout:shout".

This fixes the initial issue described in #7 