### PR TITLE
Upload rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ How Do I Use It?
 
 Don't get mad.  We use curl.
 
+First, upload the rules:
+
+    curl -X POST http://username:password@localhost:7109/rules \
+      --data-binary @path/to/rules-file
+
+After that, you can create events:
+
     curl -X POST http://username:password@localhost:7109/events --data-binary '{
       "topic"       : "some-pipeline",
       "ok"          : true,
@@ -37,9 +44,12 @@ Don't get mad.  We use curl.
 
 Shout! keeps track of the `ok`-ness of each topic you create.
 Whenever transitions occur, either a failure (ok -> not ok) or a recovery (the
-opposite), a notification is sent.  By default, the `username:password` pair
-is `shout:shout`, but this can be overridden by setting the `SHOUT_OPS_AUTH`
-environment variable before starting the Shout! process.
+opposite), a notification is sent.
+
+By default, the `username:password` pair is `shout:shout`, but this can be
+overridden by setting the `SHOUT_OPS_AUTH` environment variable for the
+operations endpoints (/events, /state, and /states) and `SHOUT_ADMIN_AUTH` for
+admin endpoint (/rules) before starting the Shout! process.
 
 No Seriously, How Do I Use It, _For Real_?
 ------------------------------------------

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ How Do I Use It?
 
 Don't get mad.  We use curl.
 
-    curl -X POST http://localhost:7109/events --data-binary '{
+    curl -X POST http://username:password@localhost:7109/events --data-binary '{
       "topic"       : "some-pipeline",
       "ok"          : true,
       "message"     : "Pipeline build #367 succeeded",
@@ -36,8 +36,10 @@ Don't get mad.  We use curl.
     }'
 
 Shout! keeps track of the `ok`-ness of each topic you create.
-Whenever transitions occur, either a failure (ok -> not ok) or a
-recovery (the opposite), a notification is sent.
+Whenever transitions occur, either a failure (ok -> not ok) or a recovery (the
+opposite), a notification is sent.  By default, the `username:password` pair
+is `shout:shout`, but this can be overridden by setting the `SHOUT_OPS_AUTH`
+environment variable before starting the Shout! process.
 
 No Seriously, How Do I Use It, _For Real_?
 ------------------------------------------

--- a/run.lisp
+++ b/run.lisp
@@ -18,9 +18,23 @@
   (or (sb-posix:getenv name)
       default))
 
+(defun bail (msg code)
+  (format t "[ERROR] ~A~%" msg)
+  (sb-ext::exit :code 1))
+
+(defun get-auth (env-var)
+  (let ((auth (env env-var nil)))
+    (if (null auth)
+      api::*default-auth*
+      (let ((idx (position #\: auth)))
+        (if (null idx)
+          (bail (format nil "Invalid authentication string in ~A: expecting \"username:password\"" env-var) 1)
+          (cons (subseq auth 0 idx) (subseq auth (+ idx 1))))))))
+
 (if (not (env "SHOUT_IT_OUT_LOUD" nil))
   (daemon:daemonize :exit-parent t
                     :pidfile (sb-posix:getenv "PID_FILE")))
 (api:run :port    (env "SHOUT_PORT"     api::*default-port*)
          :rules   (env "SHOUT_RULES"    api::*default-rules*)
-         :dbfile  (env "SHOUT_DATABASE" api::*default-dbfile*))
+         :dbfile  (env "SHOUT_DATABASE" api::*default-dbfile*)
+         :ops-auth (get-auth "SHOUT_OPS_AUTH"))

--- a/run.lisp
+++ b/run.lisp
@@ -35,6 +35,6 @@
   (daemon:daemonize :exit-parent t
                     :pidfile (sb-posix:getenv "PID_FILE")))
 (api:run :port    (env "SHOUT_PORT"     api::*default-port*)
-         :rules   (env "SHOUT_RULES"    api::*default-rules*)
          :dbfile  (env "SHOUT_DATABASE" api::*default-dbfile*)
-         :ops-auth (get-auth "SHOUT_OPS_AUTH"))
+         :ops-auth (get-auth "SHOUT_OPS_AUTH")
+         :admin-auth (get-auth "SHOUT_ADMIN_AUTH"))


### PR DESCRIPTION
Instead of using a static file, this change allows the rules to be
uploaded to the /rules endpoint as the body of a post, and retrieved as
a get.  This uses the environment variable `SHOUT_ADMIN_AUTH` to specify
the basic auth, which defaults to "shout:shout".

This removed the ability to specify rules by providing a file.  Instead
you can use curl to directly upload the rules from the file.

This fixes #8 and the parts of #7 that applies to #8.  This needs to be rebased and merged after #11 is merged, as it contains those changes as well.